### PR TITLE
Fix: have product as a proper reference for configuration rules

### DIFF
--- a/configData/SBQQ__ProductRule__c/Suggest_USB_Hub_a4dee5de-61ea-4113-9c7c-4901ed9a135e/ConfigurationRule_TELEWORKSTATION_4547e93c-acb5-44ea-b46c-4b2cc9e0548f.json
+++ b/configData/SBQQ__ProductRule__c/Suggest_USB_Hub_a4dee5de-61ea-4113-9c7c-4901ed9a135e/ConfigurationRule_TELEWORKSTATION_4547e93c-acb5-44ea-b46c-4b2cc9e0548f.json
@@ -9,6 +9,13 @@
       }
     },
     {
+      "Name": "SBQQ__Product__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "87d9eddb-8f4d-48ab-9d7c-aa8eb9d02d27"
+      }
+    },
+    {
       "Name": "SBQQ__ProductFeature__r",
       "ReferencedObject": "SBQQ__ProductFeature__c",
       "ReferencedFields": {
@@ -21,7 +28,6 @@
     "SBQQ__AscendingNestedLevel__c": "",
     "SBQQ__DescendingActionNesting__c": "",
     "SBQQ__DescendingNestedLevel__c": "",
-    "Gearset_External_Id__c": "4547e93c-acb5-44ea-b46c-4b2cc9e0548f",
-    "SBQQ__Product__r.Gearset_External_Id__c": "87d9eddb-8f4d-48ab-9d7c-aa8eb9d02d27"
+    "Gearset_External_Id__c": "4547e93c-acb5-44ea-b46c-4b2cc9e0548f"
   }
 }


### PR DESCRIPTION
#13 added a configuration rule without storing the product reference in the correct format (this deployed fine, but would cause issues later when we need to calculate dependencies)