### PR TITLE
Trailhead 3.4: Make a Dynamic Bundle with Filter Rules

### DIFF
--- a/configData/Product2/4KVIDEOCAM_dd67af25-0830-41cd-ab8c-573672a67ced/Feature_Storage_60224ce6-051c-4a17-b06a-762cdc953b90.json
+++ b/configData/Product2/4KVIDEOCAM_dd67af25-0830-41cd-ab8c-573672a67ced/Feature_Storage_60224ce6-051c-4a17-b06a-762cdc953b90.json
@@ -1,0 +1,26 @@
+{
+  "Object": "SBQQ__ProductFeature__c",
+  "References": [
+    {
+      "Name": "SBQQ__ConfiguredSKU__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "dd67af25-0830-41cd-ab8c-573672a67ced"
+      }
+    }
+  ],
+  "Fields": {
+    "Name": "Storage",
+    "SBQQ__Category__c": "",
+    "SBQQ__ConfigurationFieldSet__c": "",
+    "SBQQ__DiscountSchedule__c": "",
+    "SBQQ__DynamicProductFilterFieldSet__c": "",
+    "SBQQ__DynamicProductLookupFieldSet__c": "",
+    "SBQQ__MaxOptionCount__c": "",
+    "SBQQ__MinOptionCount__c": "0.0",
+    "SBQQ__Number__c": "20.0",
+    "SBQQ__OptionSelectionMethod__c": "Dynamic",
+    "External_ID__c": "",
+    "Gearset_External_Id__c": "60224ce6-051c-4a17-b06a-762cdc953b90"
+  }
+}

--- a/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ConfigurationRule_4KVIDEOCAM_97696d9c-cad7-4f02-965d-bca54d612456.json
+++ b/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ConfigurationRule_4KVIDEOCAM_97696d9c-cad7-4f02-965d-bca54d612456.json
@@ -1,0 +1,33 @@
+{
+  "Object": "SBQQ__ConfigurationRule__c",
+  "References": [
+    {
+      "Name": "SBQQ__ProductRule__r",
+      "ReferencedObject": "SBQQ__ProductRule__c",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "396e25b5-01a6-4b3d-916d-efeba225ee1e"
+      }
+    },
+    {
+      "Name": "SBQQ__Product__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "dd67af25-0830-41cd-ab8c-573672a67ced"
+      }
+    },
+    {
+      "Name": "SBQQ__ProductFeature__r",
+      "ReferencedObject": "SBQQ__ProductFeature__c",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "60224ce6-051c-4a17-b06a-762cdc953b90"
+      }
+    }
+  ],
+  "Fields": {
+    "SBQQ__Active__c": "true",
+    "SBQQ__AscendingNestedLevel__c": "",
+    "SBQQ__DescendingActionNesting__c": "",
+    "SBQQ__DescendingNestedLevel__c": "",
+    "Gearset_External_Id__c": "97696d9c-cad7-4f02-965d-bca54d612456"
+  }
+}

--- a/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ProductAction_131f63d8-5685-4f65-9b41-db06debd5e9c.json
+++ b/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ProductAction_131f63d8-5685-4f65-9b41-db06debd5e9c.json
@@ -1,0 +1,30 @@
+{
+  "Object": "SBQQ__ProductAction__c",
+  "References": [
+    {
+      "Name": "SBQQ__Rule__r",
+      "ReferencedObject": "SBQQ__ProductRule__c",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": "396e25b5-01a6-4b3d-916d-efeba225ee1e"
+      }
+    },
+    {
+      "Name": "SBQQ__Product__r",
+      "ReferencedObject": "Product2",
+      "ReferencedFields": {
+        "Gearset_External_Id__c": ""
+      }
+    }
+  ],
+  "Fields": {
+    "SBQQ__FilterField__c": "Product Code",
+    "SBQQ__FilterValue__c": "SDCARD",
+    "SBQQ__Operator__c": "starts with",
+    "SBQQ__Required__c": "false",
+    "SBQQ__Type__c": "Default Filter",
+    "SBQQ__ValueAttribute__c": "",
+    "SBQQ__ValueField__c": "",
+    "SBQQ__ValueObject__c": "",
+    "Gearset_External_Id__c": "131f63d8-5685-4f65-9b41-db06debd5e9c"
+  }
+}

--- a/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ProductRule_SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e.json
+++ b/configData/SBQQ__ProductRule__c/SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e/ProductRule_SD_card_filter_396e25b5-01a6-4b3d-916d-efeba225ee1e.json
@@ -1,0 +1,21 @@
+{
+  "Object": "SBQQ__ProductRule__c",
+  "References": [],
+  "Fields": {
+    "Name": "SD card filter",
+    "SBQQ__Active__c": "true",
+    "SBQQ__AdvancedCondition__c": "",
+    "SBQQ__ConditionsMet__c": "All",
+    "SBQQ__ErrorMessage__c": "",
+    "SBQQ__EvaluationEvent__c": "Load",
+    "SBQQ__EvaluationOrder__c": "",
+    "SBQQ__LookupMessageField__c": "",
+    "SBQQ__LookupObject__c": "",
+    "SBQQ__LookupProductField__c": "",
+    "SBQQ__LookupRequiredField__c": "",
+    "SBQQ__LookupTypeField__c": "",
+    "SBQQ__Scope__c": "Product",
+    "SBQQ__Type__c": "Filter",
+    "Gearset_External_Id__c": "396e25b5-01a6-4b3d-916d-efeba225ee1e"
+  }
+}


### PR DESCRIPTION
Adds a default storage filter for sd cards:
![image](https://user-images.githubusercontent.com/3789616/128688819-184088f0-5ccb-4cb5-b661-a62d80f3b2b7.png)

https://trailhead.salesforce.com/en/content/learn/modules/product-rules-in-salesforce-cpq/make-a-dynamic-bundle-with-filter-rules?trail_id=cpq-admin